### PR TITLE
Replace deprecated pkg_resources imports with importlib.metadata

### DIFF
--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -1,4 +1,11 @@
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+from importlib.metadata import PackageNotFoundError as DistributionNotFound, version as _version
+from packaging.version import Version as parse_version
+
+def get_distribution(name):
+    class _Dist:
+        def __init__(self, n):
+            self.version = _version(n)
+    return _Dist(name)
 
 for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
     try:


### PR DESCRIPTION
- Update __init__.py to fix setuptools related isse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency resolution mechanism to utilize modern Python standard library utilities while preserving all existing functionality and dialect registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->