### PR TITLE
Rename _Dist.version to _Dist.parsed_version

### DIFF
--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -4,7 +4,8 @@ from packaging.version import Version as parse_version
 def get_distribution(name):
     class _Dist:
         def __init__(self, n):
-            self.parsed_version = _version(n)
+            self.version = _version(n)
+            self.parsed_version = parse_version(self.version)
     return _Dist(name)
 
 for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -4,7 +4,7 @@ from packaging.version import Version as parse_version
 def get_distribution(name):
     class _Dist:
         def __init__(self, n):
-            self.version = _version(n)
+            self.parsed_version = _version(n)
     return _Dist(name)
 
 for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:


### PR DESCRIPTION
- After our last update, there was an error https://juice.sentry.io/issues/7322643466/?alert_rule_id=1039154&alert_type=issue&notification_uuid=5d39e278-324c-4b0d-a4dd-1b23b62f9b5f&project=2897422&referrer=slack
- Update self.version to self.parsed_version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal package version handling to include a parsed-version representation for more reliable version comparisons, improving consistency and maintainability.
  * This is an internal change with no user-facing behavior or API changes; existing version access and comparisons continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->